### PR TITLE
Set translation domain for whole form

### DIFF
--- a/src/Form/Type/ProfileFormType.php
+++ b/src/Form/Type/ProfileFormType.php
@@ -40,12 +40,10 @@ final class ProfileFormType extends AbstractType
         $builder
             ->add('locale', LocaleType::class, [
                 'label'              => 'form.locale',
-                'translation_domain' => 'NucleosProfileBundle',
                 'required'           => false,
             ])
             ->add('timezone', TimezoneType::class, [
                 'label'              => 'form.timezone',
-                'translation_domain' => 'NucleosProfileBundle',
                 'required'           => false,
             ])
         ;
@@ -54,8 +52,9 @@ final class ProfileFormType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class'    => $this->class,
-            'csrf_token_id' => 'profile',
+            'data_class'         => $this->class,
+            'csrf_token_id'      => 'profile',
+            'translation_domain' => 'NucleosProfileBundle',
         ]);
     }
 }

--- a/src/Form/Type/RegistrationFormType.php
+++ b/src/Form/Type/RegistrationFormType.php
@@ -42,16 +42,13 @@ final class RegistrationFormType extends AbstractType
         $builder
             ->add('email', EmailType::class, [
                 'label'              => 'form.email',
-                'translation_domain' => 'NucleosProfileBundle',
             ])
             ->add('username', TextType::class, [
                 'label'              => 'form.username',
-                'translation_domain' => 'NucleosProfileBundle',
             ])
             ->add('plainPassword', RepeatedType::class, [
                 'type'            => PasswordType::class,
                 'options'         => [
-                    'translation_domain' => 'NucleosProfileBundle',
                     'attr'               => [
                         'autocomplete' => 'new-password',
                     ],
@@ -66,8 +63,9 @@ final class RegistrationFormType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class'    => $this->class,
-            'csrf_token_id' => 'registration',
+            'data_class'         => $this->class,
+            'csrf_token_id'      => 'registration',
+            'translation_domain' => 'NucleosProfileBundle',
         ]);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

Set translation domain for whole form. All form extensions will use `NucleosProfileBundle` as domain.
