### PR TITLE
Fix wrong EmailConfirmationListener argument

### DIFF
--- a/src/Resources/config/email_confirmation.php
+++ b/src/Resources/config/email_confirmation.php
@@ -21,7 +21,7 @@ return static function (ContainerConfigurator $container): void {
             ->tag('kernel.event_subscriber')
             ->args([
                 new Reference('nucleos_profile.mailer'),
-                new Reference('nucleos_profile.util.token_generator'),
+                new Reference('nucleos_user.util.token_generator'),
                 new Reference('router'),
                 new Reference('session'),
             ])


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

https://github.com/nucleos/NucleosProfileBundle/commit/d9b9fc8928ecb4588e8218e4c8340b4736270b63 introduced a wrong service argument.
