### PR TITLE
Fix the mail class used for registration

### DIFF
--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -11,7 +11,7 @@
 
 namespace Nucleos\ProfileBundle\Mailer;
 
-use Nucleos\UserBundle\Mailer\Mail\ResettingMail;
+use Nucleos\ProfileBundle\Mailer\Mail\RegistrationMail;
 use Nucleos\UserBundle\Model\UserInterface;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface as SymfonyMailer;
@@ -64,7 +64,7 @@ final class Mailer implements MailerInterface
             UrlGeneratorInterface::ABSOLUTE_URL
         );
 
-        $mail = (new ResettingMail())
+        $mail = (new RegistrationMail())
             ->to(new Address($user->getEmail()))
             ->subject($this->translator->trans('registration.email.subject', [
                 '%username%' => $user->getUsername(),


### PR DESCRIPTION
Closes #240

The registration workflow uses the email class provided by the NucleosUserBundle to reset a user's password. This commit makes the workflow use the dedicated registration email instead.