### PR TITLE
Remove egulias/email-validator dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "egulias/email-validator": "^2.1.10",
+        "egulias/email-validator": "^2.1.10 || ^3.0",
         "nucleos/user-bundle": "^1.7",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "egulias/email-validator": "^2.1.10 || ^3.0",
         "nucleos/user-bundle": "^1.7",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",


### PR DESCRIPTION
When using this bundle, we can't use `egulias/email-validator` at version 3.x

However, Symfony allows it 

https://github.com/symfony/validator/blob/7474c6839fb9386e98afc478047500e90230fe83/composer.json#L45
