### PR TITLE
Allow newer Doctrine dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "doctrine/persistence": "^2.2.2",
+        "doctrine/persistence": "^2.2 || ^3.0",
         "nucleos/user-bundle": "^2.0",
         "symfony/config": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",


### PR DESCRIPTION
## Subject

`doctrine/persistence` was fixed to version `2.2.2`. Current versions are `2.5.4` and `3.0.3`. Hence, I've added `^3.0` in order to support the new major version as well. Thought about adding `^2.3`, `^2.4` and `^2.5`, too, but it didn't feel right, so I decided against it.