### PR TITLE
Allow using emails with display name

### DIFF
--- a/src/Mailer/SimpleRegistrationMailer.php
+++ b/src/Mailer/SimpleRegistrationMailer.php
@@ -60,7 +60,7 @@ final class SimpleRegistrationMailer implements RegistrationMailer
         ;
 
         if (null !== $this->fromEmail) {
-            $mail->from(new Address($this->fromEmail));
+            $mail->from(Address::create($this->fromEmail));
         }
 
         $this->mailer->send($mail);


### PR DESCRIPTION
When the bundle is configured like this: 

```yaml
nucleos_profile:
    registration:
        confirmation:
            from_email: "Foo <foo@bar.com>"
```

It throws the following exception:

```
Email "Foo <foo@bar.com>" does not comply with addr-spec of RFC 2822.
```

Using `Address::create` fixes this. It's done like this in [NucleosUserBundle](https://github.com/nucleos/NucleosUserBundle/blob/e2932110138cb0e58868438a89c30505e702ecc8/src/Mailer/SimpleResettingMailer.php#L52)
